### PR TITLE
0.1.1 release - fix a few places where we didn't update to 19.8 correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.1] - 2019-10-16
+Fix some places where the version hadn't been updated to 19.8.0 correctly.
+
 ## [0.1.0] - 2019-10-08
 Initial plugin release.
 
-[Unreleased]: https://github.com/amperity/gocd-aurora-elastic-agent/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/amperity/gocd-aurora-elastic-agent/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/amperity/gocd-aurora-elastic-agent/releases/tag/v0.1.1
 [0.1.0]: https://github.com/amperity/gocd-aurora-elastic-agent/releases/tag/v0.1.0

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/gocd-aurora-elastic-agent "0.2.0-SNAPSHOT"
+(defproject amperity/gocd-aurora-elastic-agent "0.1.1-SNAPSHOT"
   :description "A plugin for GoCD providing elastic agent support via Apache Aurora."
   :url "https://github.com/amperity/gocd-aurora-elastic-agent"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
   :profiles
   {:provided
    {:dependencies
-    [[cd.go.plugin/go-plugin-api "19.7.0"]
+    [[cd.go.plugin/go-plugin-api "19.8.0"]
      [com.google.guava/guava "23.0"]]}
 
    :repl

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/gocd-aurora-elastic-agent "0.1.1"
+(defproject amperity/gocd-aurora-elastic-agent "0.2.0-SNAPSHOT"
   :description "A plugin for GoCD providing elastic agent support via Apache Aurora."
   :url "https://github.com/amperity/gocd-aurora-elastic-agent"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/gocd-aurora-elastic-agent "0.1.1-SNAPSHOT"
+(defproject amperity/gocd-aurora-elastic-agent "0.1.1"
   :description "A plugin for GoCD providing elastic agent support via Apache Aurora."
   :url "https://github.com/amperity/gocd-aurora-elastic-agent"
   :license {:name "Apache License 2.0"

--- a/resources/plugin.xml
+++ b/resources/plugin.xml
@@ -2,7 +2,7 @@
 <go-plugin id="amperity.gocd.agent.aurora" version="1">
   <about>
     <name>Aurora Elastic Agents</name>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
     <target-go-version>19.8.0</target-go-version>
     <description>Manages elastic agents running on Apache Aurora/Mesos.</description>
 

--- a/resources/plugin.xml
+++ b/resources/plugin.xml
@@ -2,7 +2,7 @@
 <go-plugin id="amperity.gocd.agent.aurora" version="1">
   <about>
     <name>Aurora Elastic Agents</name>
-    <version>0.1.1</version>
+    <version>0.2.0-SNAPSHOT</version>
     <target-go-version>19.8.0</target-go-version>
     <description>Manages elastic agents running on Apache Aurora/Mesos.</description>
 

--- a/resources/plugin.xml
+++ b/resources/plugin.xml
@@ -2,7 +2,7 @@
 <go-plugin id="amperity.gocd.agent.aurora" version="1">
   <about>
     <name>Aurora Elastic Agents</name>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.1.1</version>
     <target-go-version>19.8.0</target-go-version>
     <description>Manages elastic agents running on Apache Aurora/Mesos.</description>
 

--- a/src/amperity/gocd/agent/aurora/cluster.clj
+++ b/src/amperity/gocd/agent/aurora/cluster.clj
@@ -5,8 +5,8 @@
 
 
 (def default-agent-source-url
-  (let [version "19.7.0"
-        build "9567"
+  (let [version "19.8.0"
+        build "9915"
         coord (str version "-" build)]
     (str "https://download.gocd.org/binaries/" coord
          "/generic/go-agent-" coord ".zip")))


### PR DESCRIPTION
I won't squash and merge, but I'm doing this in one PR for efficiency. I'll create a release at 7337bcd after this is merged.