### PR TITLE
Require agents to be in the requested cluster

### DIFF
--- a/src/amperity/gocd/agent/aurora/plugin.clj
+++ b/src/amperity/gocd/agent/aurora/plugin.clj
@@ -343,7 +343,8 @@
         decision (scheduler/should-assign-work?
                    @<scheduler>
                    agent-profile
-                   agent-id)]
+                   agent-id
+                   cluster-profile)]
     (when decision
       (log/info "Assigning job %s to agent %s"
                 (server/job-label gocd-job)


### PR DESCRIPTION
This PR updates the scheduler to check the cluster of the agent against the cluster of the requested profile to make sure they match before allowing work to be scheduled on that agent.