### PR TITLE
Style improvements for the cluster status page

### DIFF
--- a/src/amperity/gocd/agent/aurora/plugin.clj
+++ b/src/amperity/gocd/agent/aurora/plugin.clj
@@ -178,6 +178,7 @@
         aurora-env (:aurora_env cluster-profile)]
     (view-response
       [:div
+       [:style "ol,ul,li { float: none; }"]
        [:h2 "Cluster Status"]
        [:h3 "Profile"]
        [:pre (pr-str cluster-profile)]
@@ -195,6 +196,7 @@
        (->>
          (:agents @<scheduler>)
          (filter (comp #{aurora-cluster} :aurora-cluster agent/parse-id key))
+         (sort-by :state)
          (map (fn render-agent
                 [[agent-id agent-state]]
                 [:div


### PR DESCRIPTION
This makes the lists render correctly (well, less badly, anyway) and also sorts the agents by state.