### PR TITLE
Optionally allow specifying agent environments

### DIFF
--- a/resources/amperity/gocd/agent/aurora/elastic-agent-profile-view.html
+++ b/resources/amperity/gocd/agent/aurora/elastic-agent-profile-view.html
@@ -5,6 +5,17 @@
   <span class="form_error" ng-show="GOINPUTNAME[agent_tag].$error.server">{{GOINPUTNAME[agent_tag].$error.server}}</span>
 </div>
 
+<div class="form_item_block">
+  <label>Environments:</label>
+  <p>
+    (Optional) Comma-separated list of environments to launch the agent with.
+    If set, will not allow jobs to launch with this agent profile unless they're
+    in one of the specified environments.
+  </p>
+  <input type="text" ng-model="environments" ng-required="true" placeholder="dev,stage,prod"/>
+  <span class="form_error" ng-show="GOINPUTNAME[environments].$error.server">{{GOINPUTNAME[environments].$error.server}}</span>
+</div>
+
 <fieldset>
   <legend style="font-size: 18px; margin-top: 15px;">Agent Resources</legend>
   <p>Job resources to request for each agent of this type.</p>

--- a/src/amperity/gocd/agent/aurora/agent.clj
+++ b/src/amperity/gocd/agent/aurora/agent.clj
@@ -93,9 +93,9 @@
      (when-not (re-matches #"[a-z]+" (:agent_tag settings))
        {:key :agent_tag
         :message "Agent tag must consist of lowercase letters"})
-     (when-let [environments (not-empty (:environments settings))]
-       (when-not (re-matches #"[a-zA-Z0-9_\-]{1}[a-zA-Z0-9_\-.]*(,[a-zA-Z0-9_\-]{1}[a-zA-Z0-9_\-.]*)*"
-                             environments)
+     (when (not (str/blank? (:environments settings)))
+       (when-not (re-matches #"[a-zA-Z0-9_\-][a-zA-Z0-9_\-.]*(,[a-zA-Z0-9_\-][a-zA-Z0-9_\-.]*)*"
+                             (:environments settings))
          {:key :environments
           :message "Environments list must be a comma-separated list of environment names"}))
      (validate-float settings :cpu "cpu allocation" 0.1 32.0)
@@ -196,9 +196,9 @@
   [agent-id state agent-profile gocd-environment]
   {:agent-id agent-id
    :state state
-   :environments (if-let [agent-environments (not-empty (:environments agent-profile))]
-                   agent-environments
-                   gocd-environment)
+   :environments (if (str/blank? (:environments agent-profile))
+                   gocd-environment
+                   (:environments agent-profile))
    :resources (profile->resources agent-profile)
    :last-active (now)
    :events []})

--- a/src/amperity/gocd/agent/aurora/job.clj
+++ b/src/amperity/gocd/agent/aurora/job.clj
@@ -22,11 +22,11 @@
         (throw (IllegalArgumentException.
                  (str "Agent job settings must include a " (name k)
                       " string, got: " (pr-str v)))))))
-  (when-let [environment (:auto-register-environment params)]
-    (when-not (string? environment)
+  (when-let [environments (:auto-register-environments params)]
+    (when-not (string? environments)
       (throw (IllegalArgumentException.
-               (str "Agent job setting auto-register-environment must be a"
-                    " string, got: " (pr-str environment)))))))
+               (str "Agent job setting auto-register-environments must be a"
+                    " string, got: " (pr-str environments)))))))
 
 
 
@@ -89,8 +89,8 @@
         (clean autoregister-properties-path)
         (autoregister-property "agent.auto.register.key" (:auto-register-key params))
         (autoregister-property "agent.auto.register.hostname" (:auto-register-hostname params))
-        (when-let [environment (:auto-register-environment params)]
-          (autoregister-property "agent.auto.register.environments" environment))
+        (when-let [environments (:auto-register-environments params)]
+          (autoregister-property "agent.auto.register.environments" environments))
         (autoregister-property "agent.auto.register.elasticAgent.pluginId" (:elastic-plugin-id params))
         (autoregister-property "agent.auto.register.elasticAgent.agentId" (:elastic-agent-id params))
         (str "base64 -d <<<'" (u/b64-encode-str logback-xml) "' > go-agent/config/agent-bootstrapper-logback.xml")

--- a/src/amperity/gocd/agent/aurora/plugin.clj
+++ b/src/amperity/gocd/agent/aurora/plugin.clj
@@ -208,7 +208,7 @@
                    (str (:last-active agent-state))
                    (when (:idle? agent-state)
                      " (idle)")]
-                  [:li [:strong "environment:"] " " (:environment agent-state :???)]
+                  [:li [:strong "environments:"] " " (:environments agent-state :???)]
                   [:li [:strong "resources:"]
                    [:ul
                     (for [[k v] (:resources agent-state)]
@@ -332,7 +332,7 @@
 ;; When there are multiple agents available to run a job, the server will
 ;; ask the plugin if jobs should be assigned to a particular agent. The
 ;; request will contain information about the agent, the job configuration
-;; and the environment that the agent belongs to. This allows plugin to
+;; and the environments that the agent belongs to. This allows plugin to
 ;; decide if proposed agent is suitable to schedule a job on it. For
 ;; example, plugin can check if flavor or region of VM is suitable.
 (defmethod handle-request "cd.go.elastic-agent.should-assign-work"

--- a/src/amperity/gocd/agent/aurora/scheduler.clj
+++ b/src/amperity/gocd/agent/aurora/scheduler.clj
@@ -261,10 +261,9 @@
                             :agent-source-url source-url
                             :auto-register-hostname agent-name
                             :auto-register-environments
-                            (if-let [agent-environments
-                                     (not-empty (:environments agent-profile))]
-                              agent-environments
-                              (:gocd-environment request))
+                            (if (str/blank? (:environments agent-profile))
+                              (:gocd-environment request)
+                              (:environments agent-profile))
                             :auto-register-key (:gocd-register-key request)
                             :elastic-plugin-id u/plugin-id
                             :elastic-agent-id agent-id

--- a/test/amperity/gocd/agent/aurora/agent_test.clj
+++ b/test/amperity/gocd/agent/aurora/agent_test.clj
@@ -1,0 +1,28 @@
+(ns amperity.gocd.agent.aurora.agent-test
+  (:require
+    [amperity.gocd.agent.aurora.agent :as agent]
+    [clojure.test :refer [deftest testing is]]))
+
+
+(deftest validate-settings
+  (testing "happy path"
+    (let [input
+          {:agent_tag "build"
+           :cpu "1.0"
+           :ram "512"
+           :disk "1024"}]
+      (is (= [] (agent/validate-settings input)))
+      (is (= [] (agent/validate-settings (assoc input :environments ""))))
+      (is (= [] (agent/validate-settings (assoc input :environments "foo-env"))))
+      (is (= [] (agent/validate-settings (assoc input :environments "foo-env,bar-env,baz_env"))))))
+  (testing "failures"
+    (let [input
+          {:agent_tag "haha invalid"
+           :environments "i don't like spaces either"
+           :cpu "french"
+           :ram "seventy.five"
+           :disk "75"}
+          result (agent/validate-settings input)]
+      (is (= 5 (count result)))
+      (is (= #{:agent_tag :environments :cpu :ram :disk}
+             (into #{} (map :key) result))))))


### PR DESCRIPTION
This allows you to specify a list of environments for each agent
profile. If set, the agent will autoregister with all specified
environments, not just the one the job was launched as.

Additionally, the scheduler will not launch new Aurora jobs to handle a
given GoCD job if the GoCD job is not in one of the allowed environments
for the requested cluster profile.

Also adds some very simple testing for agent profile validation.